### PR TITLE
feat: Rename requestprimitive to resp type

### DIFF
--- a/src/command_dispatcher.rs
+++ b/src/command_dispatcher.rs
@@ -1,6 +1,6 @@
 use super::commands::Command;
 use crate::commands::hello::HelloCommand;
-use crate::types::lib::RequestPrimitive;
+use crate::types::lib::RESPType;
 use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
@@ -34,11 +34,11 @@ impl CommandDispatcher {
         })
     }
 
-    fn extract_commands(command: Vec<RequestPrimitive>) -> Vec<String> {
+    fn extract_commands(command: Vec<RESPType>) -> Vec<String> {
         let mut bulk_string_prefixes = Vec::new();
         for c in command {
             match c {
-                RequestPrimitive::BulkString(s) => {
+                RESPType::BulkString(s) => {
                     bulk_string_prefixes.push(s);
                 }
                 _ => break,
@@ -57,7 +57,7 @@ impl CommandDispatcher {
 
     pub(crate) fn dispatch(
         &self,
-        command: Vec<RequestPrimitive>,
+        command: Vec<RESPType>,
     ) -> Result<Arc<dyn Command>, Box<dyn Error>> {
         let command_choices = Self::extract_commands(command);
         for command_choice in command_choices.clone() {

--- a/src/redis_server.rs
+++ b/src/redis_server.rs
@@ -43,7 +43,7 @@ impl RedisServer {
                 Ok(value) => {
                     log::info!("Parsed: {:?}", value);
                     let command_prefixes = match value {
-                        crate::types::lib::RequestPrimitive::Array(a) => {
+                        crate::types::lib::RESPType::Array(a) => {
                             if a.elements.len() == 1 || a.elements.len() == 2 {
                                 a.elements
                             } else {

--- a/src/types/lib_test.rs
+++ b/src/types/lib_test.rs
@@ -17,7 +17,7 @@ mod tests {
         let mut parser = Parser::new(BufReader::new(StringReader::new("+Hello")));
         let value = parser.next().unwrap();
         match value {
-            crate::types::lib::RequestPrimitive::BulkString(s) => {
+            crate::types::lib::RESPType::BulkString(s) => {
                 assert_eq!(s, "Hello");
             }
             _ => panic!("Expected BulkString"),
@@ -29,7 +29,7 @@ mod tests {
         let mut parser = Parser::new(BufReader::new(StringReader::new("-Error")));
         let value = parser.next().unwrap();
         match value {
-            crate::types::lib::RequestPrimitive::Error(s) => {
+            crate::types::lib::RESPType::Error(s) => {
                 assert_eq!(s, "Error");
             }
             _ => panic!("Expected Error"),
@@ -41,7 +41,7 @@ mod tests {
         let mut parser = Parser::new(BufReader::new(StringReader::new(":123")));
         let value = parser.next().unwrap();
         match value {
-            crate::types::lib::RequestPrimitive::Integer(i) => {
+            crate::types::lib::RESPType::Integer(i) => {
                 assert_eq!(i, 123);
             }
             _ => panic!("Expected Integer"),
@@ -53,16 +53,16 @@ mod tests {
         let mut parser = Parser::new(BufReader::new(StringReader::new("*2\r\n+Hello\r\n+World")));
         let value = parser.next().unwrap();
         match value {
-            crate::types::lib::RequestPrimitive::Array(a) => {
+            crate::types::lib::RESPType::Array(a) => {
                 assert_eq!(a.elements.len(), 2);
                 match &a.elements[0] {
-                    crate::types::lib::RequestPrimitive::BulkString(s) => {
+                    crate::types::lib::RESPType::BulkString(s) => {
                         assert_eq!(s, "Hello");
                     }
                     _ => panic!("Expected BulkString"),
                 }
                 match &a.elements[1] {
-                    crate::types::lib::RequestPrimitive::BulkString(s) => {
+                    crate::types::lib::RESPType::BulkString(s) => {
                         assert_eq!(s, "World");
                     }
                     _ => panic!("Expected BulkString"),
@@ -78,16 +78,16 @@ mod tests {
         )));
         let value = parser.next().unwrap();
         match value {
-            crate::types::lib::RequestPrimitive::Array(a) => {
+            crate::types::lib::RESPType::Array(a) => {
                 assert_eq!(a.elements.len(), 2);
                 match &a.elements[0] {
-                    crate::types::lib::RequestPrimitive::BulkString(s) => {
+                    crate::types::lib::RESPType::BulkString(s) => {
                         assert_eq!(s, "Hello");
                     }
                     _ => panic!("Expected BulkString"),
                 }
                 match &a.elements[1] {
-                    crate::types::lib::RequestPrimitive::BulkString(s) => {
+                    crate::types::lib::RESPType::BulkString(s) => {
                         assert_eq!(s, "World");
                     }
                     _ => panic!("Expected BulkString"),


### PR DESCRIPTION
These types are not just used at request times, but can (and will) be used at response times as well. So renaming the struct to align with terminology at https://redis.io/docs/latest/develop/reference/protocol-spec/

Signed-off-by: Achal Shah <achals@gmail.com>
